### PR TITLE
docs: add branch details

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,11 @@ Before running _sbt compile_ on the core Equella code base, do the following
 1. Copy the Kaltura directory from the {Equella-Kaltura} cloned directory into your Equella Plugins into the core Equella Plugins directory {Equella-core-repo}/Source/Plugins
 
 Proceed with the normal build process for openEquella.  Kaltura integration will be enabled.
+
+## Branches
+With the advent of the Spring 5 / Hibernate 5 upgrade in `openEQUELLA` with `2020.2.x`, the `openEQUELLA-Kaltura` repo needed to have a loose mirroring of branches to the core repo.
+
+* `develop` - Generally, all new development efforts should use this branch or a branch from this
+* `master` - Represents the latest `openEQUELLA` release matching the `openEQUELLA` > `master` branch
+* `pre-2020.2-support` - Any builds prior to `2020.2.x` should use this branch
+


### PR DESCRIPTION
Due to the Spring 5 / Hibernate 5 addition into `2020.2.x`, this aims to clarify the 3 primary branches of the `openEQUELLA-Kaltura` repo.