### PR TITLE
Support externalId AttachmentBean field

### DIFF
--- a/Kaltura/com.tle.web.wizard.controls.kaltura/src/com/tle/web/controls/kaltura/KalturaAttachmentBean.java
+++ b/Kaltura/com.tle.web.wizard.controls.kaltura/src/com/tle/web/controls/kaltura/KalturaAttachmentBean.java
@@ -19,6 +19,7 @@ package com.tle.web.controls.kaltura;
 import java.util.Date;
 
 import com.tle.web.api.item.equella.interfaces.beans.EquellaAttachmentBean;
+import java.util.Optional;
 
 @SuppressWarnings("nls")
 public class KalturaAttachmentBean extends EquellaAttachmentBean
@@ -30,6 +31,12 @@ public class KalturaAttachmentBean extends EquellaAttachmentBean
 	private String kalturaServer;
 	private String tags;
 	private long duration;
+
+	/**
+	 * A string which is made up of the core elements required to generate a embedded Kaltura viewer.
+	 * It has the format of {@code <partner_id>/<uiconf_id>/<entryId>}.
+	 */
+	private String externalId;
 
 	@Override
 	public String getRawAttachmentType()
@@ -105,5 +112,14 @@ public class KalturaAttachmentBean extends EquellaAttachmentBean
 	public void setKalturaServer(String kalturaServer)
 	{
 		this.kalturaServer = kalturaServer;
+	}
+
+	public void setExternalId(int partnerId, int uiConfId) {
+		this.externalId = String.format("%d/%d/%s", partnerId, uiConfId, mediaId);
+	}
+
+	@Override
+	public Optional<String> getExternalId() {
+		return Optional.of(externalId);
 	}
 }

--- a/Kaltura/com.tle.web.wizard.controls.kaltura/src/com/tle/web/controls/kaltura/KalturaAttachmentSerializer.java
+++ b/Kaltura/com.tle.web.wizard.controls.kaltura/src/com/tle/web/controls/kaltura/KalturaAttachmentSerializer.java
@@ -16,24 +16,28 @@
 
 package com.tle.web.controls.kaltura;
 
-import java.util.Date;
-import java.util.Map;
-
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMap.Builder;
 import com.google.inject.Singleton;
 import com.tle.beans.item.attachments.Attachment;
 import com.tle.beans.item.attachments.CustomAttachment;
 import com.tle.common.kaltura.KalturaUtils;
+import com.tle.common.kaltura.entity.KalturaServer;
 import com.tle.core.guice.Bind;
 import com.tle.core.item.edit.ItemEditor;
 import com.tle.core.item.serializer.AbstractAttachmentSerializer;
+import com.tle.core.kaltura.service.KalturaService;
 import com.tle.web.api.item.equella.interfaces.beans.EquellaAttachmentBean;
+import java.util.Date;
+import java.util.Map;
+import javax.inject.Inject;
 
 @Bind
 @Singleton
 public class KalturaAttachmentSerializer extends AbstractAttachmentSerializer
 {
+	@Inject
+	private KalturaService kalturaService;
 
 	@Override
 	public EquellaAttachmentBean serialize(Attachment attachment)
@@ -66,6 +70,10 @@ public class KalturaAttachmentSerializer extends AbstractAttachmentSerializer
 			}
 			kbean.setDuration(durInt);
 		}
+
+		KalturaServer ks = kalturaService.getByUuid(kbean.getKalturaServer());
+		kbean.setExternalId(ks.getPartnerId(), kalturaService.getDefaultKdpUiConf(ks).id);
+
 		return kbean;
 	}
 


### PR DESCRIPTION
Requires https://github.com/openequella/openEQUELLA/pull/3220

This adds support to serialise key details into the externalId field of the attachment to support embedding players for the Kaltura attachments in the oEQ New UI.

To do this efficiently, also required caching to be added for the retrieval of the default player UI conf. This is a value which once established changes rarely (foreseeably never), and yet to serialise multiple attachments would require multiple calls out to the Kaltura server/platform. This could probably have been done as a memoize, but just in case I've done it with a TTL cache.