### PR TITLE
chore: update KalturaClient to v17.18.1

### DIFF
--- a/Kaltura/com.tle.core.kaltura/build.sbt
+++ b/Kaltura/com.tle.core.kaltura/build.sbt
@@ -1,7 +1,7 @@
 lazy val Kaltura = config("kaltura") describedAs("kaltura jars")
 lazy val CustomCompile = config("compile") extend Kaltura
 
-libraryDependencies += "com.kaltura" % "kalturaClient" % "3.2.1" % Kaltura
+libraryDependencies += "com.kaltura" % "kalturaApiClient" % "17.18.1" % Kaltura
 
 excludeDependencies := Seq(
   "commons-logging" % "commons-logging",

--- a/Kaltura/com.tle.core.kaltura/src/com/tle/core/kaltura/service/KalturaService.java
+++ b/Kaltura/com.tle.core.kaltura/src/com/tle/core/kaltura/service/KalturaService.java
@@ -16,16 +16,17 @@
 
 package com.tle.core.kaltura.service;
 
+import com.kaltura.client.types.ListResponse;
 import java.util.Collection;
 import java.util.List;
 
 import com.tle.common.beans.exception.InvalidDataException;
-import com.kaltura.client.KalturaApiException;
-import com.kaltura.client.KalturaClient;
-import com.kaltura.client.enums.KalturaSessionType;
-import com.kaltura.client.types.KalturaMediaEntry;
-import com.kaltura.client.types.KalturaMediaListResponse;
-import com.kaltura.client.types.KalturaUiConf;
+import com.kaltura.client.types.APIException;
+import com.kaltura.client.Client;
+import com.kaltura.client.enums.SessionType;
+import com.kaltura.client.types.MediaEntry;
+import com.kaltura.client.services.MediaService.ListMediaBuilder;
+import com.kaltura.client.types.UiConf;
 import com.tle.common.kaltura.entity.KalturaServer;
 import com.tle.common.kaltura.service.RemoteKalturaService;
 import com.tle.core.entity.service.AbstractEntityService;
@@ -33,17 +34,17 @@ import com.tle.core.entity.EntityEditingBean;
 
 public interface KalturaService extends AbstractEntityService<EntityEditingBean, KalturaServer>, RemoteKalturaService
 {
-	KalturaMediaListResponse searchMedia(KalturaClient client, Collection<String> keywords, int page, int limit);
+	ListResponse<MediaEntry> searchMedia(Client client, Collection<String> keywords, int page, int limit);
 
-	KalturaMediaEntry getMediaEntry(KalturaClient client, String entryId);
+	MediaEntry getMediaEntry(Client client, String entryId);
 
-	KalturaMediaListResponse getMediaEntries(KalturaClient client, List<String> entryIds);
+	ListResponse<MediaEntry> getMediaEntries(Client client, List<String> entryIds);
 
-	KalturaClient getKalturaClient(KalturaServer kalturaServer, KalturaSessionType type) throws KalturaApiException;
+	Client getKalturaClient(KalturaServer kalturaServer, SessionType type) throws APIException;
 
-	KalturaUiConf getDefaultKdpUiConf(KalturaServer ks);
+	UiConf getDefaultKdpUiConf(KalturaServer ks);
 
-	boolean testKalturaSetup(KalturaServer kalturaServer, KalturaSessionType type) throws KalturaApiException;
+	boolean testKalturaSetup(KalturaServer kalturaServer, SessionType type) throws APIException;
 
 	String addKalturaServer(KalturaServer kalturaServer) throws InvalidDataException;
 
@@ -51,7 +52,7 @@ public interface KalturaService extends AbstractEntityService<EntityEditingBean,
 
 	KalturaServer getForEdit(String kalturaServerUuid);
 
-	List<KalturaUiConf> getPlayers(KalturaServer ks);
+	List<UiConf> getPlayers(KalturaServer ks);
 
 	void enable(KalturaServer ks, boolean enable);
 

--- a/Kaltura/com.tle.core.kaltura/src/com/tle/core/kaltura/service/KalturaServiceImpl.java
+++ b/Kaltura/com.tle.core.kaltura/src/com/tle/core/kaltura/service/KalturaServiceImpl.java
@@ -18,29 +18,31 @@ package com.tle.core.kaltura.service;
 
 import com.google.common.base.Charsets;
 import com.google.common.base.Joiner;
-import com.google.common.base.Throwables;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.io.Resources;
 import com.google.inject.Singleton;
-import com.kaltura.client.KalturaApiException;
-import com.kaltura.client.KalturaClient;
-import com.kaltura.client.KalturaConfiguration;
-import com.kaltura.client.enums.KalturaEntryStatus;
-import com.kaltura.client.enums.KalturaMediaType;
-import com.kaltura.client.enums.KalturaSessionType;
-import com.kaltura.client.enums.KalturaUiConfCreationMode;
-import com.kaltura.client.enums.KalturaUiConfObjType;
-import com.kaltura.client.services.KalturaMediaService;
-import com.kaltura.client.services.KalturaSessionService;
-import com.kaltura.client.services.KalturaUiConfService;
-import com.kaltura.client.types.KalturaFilterPager;
-import com.kaltura.client.types.KalturaMediaEntry;
-import com.kaltura.client.types.KalturaMediaEntryFilter;
-import com.kaltura.client.types.KalturaMediaListResponse;
-import com.kaltura.client.types.KalturaUiConf;
-import com.kaltura.client.types.KalturaUiConfFilter;
-import com.kaltura.client.types.KalturaUiConfListResponse;
+import com.kaltura.client.APIOkRequestsExecutor;
+import com.kaltura.client.services.SystemService;
+import com.kaltura.client.types.APIException;
+import com.kaltura.client.Client;
+import com.kaltura.client.Configuration;
+import com.kaltura.client.enums.EntryStatus;
+import com.kaltura.client.enums.MediaType;
+import com.kaltura.client.enums.SessionType;
+import com.kaltura.client.enums.UiConfCreationMode;
+import com.kaltura.client.enums.UiConfObjType;
+import com.kaltura.client.services.MediaService;
+import com.kaltura.client.services.SessionService;
+import com.kaltura.client.services.UiConfService;
+import com.kaltura.client.types.FilterPager;
+import com.kaltura.client.types.ListResponse;
+import com.kaltura.client.types.MediaEntry;
+import com.kaltura.client.types.MediaEntryFilter;
+import com.kaltura.client.types.UiConf;
+import com.kaltura.client.types.UiConfFilter;
+import com.kaltura.client.utils.request.RequestElement;
+import com.kaltura.client.utils.response.base.Response;
 import com.tle.beans.entity.BaseEntityLabel;
 import com.tle.common.Check;
 import com.tle.common.EntityPack;
@@ -68,422 +70,362 @@ import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
 import org.springframework.transaction.annotation.Transactional;
 
-
 @Bind(KalturaService.class)
 @Singleton
 @SuppressWarnings("nls")
 @SecureEntity("KALTURA")
-public class KalturaServiceImpl extends AbstractEntityServiceImpl<EntityEditingBean, KalturaServer, KalturaService>
-	implements
-		KalturaService
-{
-	protected final KalturaDao kalturaDao;
+public class KalturaServiceImpl
+    extends AbstractEntityServiceImpl<EntityEditingBean, KalturaServer, KalturaService>
+    implements KalturaService {
+  protected final KalturaDao kalturaDao;
 
-	@Inject
-	public KalturaServiceImpl(KalturaDao dao)
-	{
-		super(Node.KALTURA, dao);
-		kalturaDao = dao;
-	}
+  private APIOkRequestsExecutor executor = new APIOkRequestsExecutor();
 
-	// Increase number on the end to replace
-	private static final String EQUELLA_KDP_UICONF = "EQUELLA-KDP-UICONF_5.2-114";
+  @Inject
+  public KalturaServiceImpl(KalturaDao dao) {
+    super(Node.KALTURA, dao);
+    kalturaDao = dao;
+  }
 
-	// A cache to protect against excessive calls to Kaltura. There is a small risk of a period when
-	// incorrect results could then be returned - however if needs be a restart can navigate it.
-	private final Cache<String, KalturaUiConf> defaultUiConfCache = CacheBuilder.newBuilder()
-			.expireAfterWrite(1,
-					TimeUnit.HOURS).build();
+  // Increase number on the end to replace
+  private static final String EQUELLA_KDP_UICONF = "EQUELLA-KDP-UICONF_5.2-114";
 
-	@Override
-	public KalturaMediaListResponse searchMedia(KalturaClient client, Collection<String> keywords, int page, int limit)
-	{
-		KalturaMediaService ms = client.getMediaService();
-		KalturaMediaEntryFilter ef = new KalturaMediaEntryFilter();
-		String joined = "";
+  // A cache to protect against excessive calls to Kaltura. There is a small risk of a period when
+  // incorrect results could then be returned - however if needs be a restart can navigate it.
+  private final Cache<String, UiConf> defaultUiConfCache =
+      CacheBuilder.newBuilder().expireAfterWrite(1, TimeUnit.HOURS).build();
 
-		if( !Check.isEmpty(keywords) && keywords != null )
-		{
-			joined = Joiner.on(',').join(keywords).trim();
-			joined = joined.replaceAll("[\\*\\?\\~]", "");
-			if( !Objects.equals(joined, "") )
-			{
-				ef.tagsNameMultiLikeOr = joined.toLowerCase();
-				ef.mediaTypeIn = Joiner.on(",").join(KalturaMediaType.VIDEO.hashCode, KalturaMediaType.AUDIO.hashCode);
-				ef.orderBy = "+name"; // KalturaMediaEntryOrderBy.NAME_ASC.name();
-				KalturaFilterPager pager = new KalturaFilterPager();
-				pager.pageSize = limit;
-				pager.pageIndex = page;
+  private <T> T execute(RequestElement<T> request) throws APIException {
+    Response<?> res = executor.execute(request);
+    if (res.isSuccess()) {
+      return (T) res.results;
+    }
 
-				try
-				{
-					return ms.list(ef, pager);
-				}
-				catch( KalturaApiException e )
-				{
-					throw Throwables.propagate(e);
-				}
-			}
-		}
+    throw res.error;
+  }
 
-		// No results (or blank search)
-		return null;
-	}
+  @Override
+  public ListResponse<MediaEntry> searchMedia(
+      Client client, Collection<String> keywords, int page, int limit) {
+    MediaEntryFilter ef = new MediaEntryFilter();
+    String joined = "";
 
-	@Override
-	public KalturaClient getKalturaClient(KalturaServer kalturaServer, KalturaSessionType type)
-		throws KalturaApiException
-	{
-		int pid = kalturaServer.getPartnerId();
-		String secret = type.equals(KalturaSessionType.ADMIN) ? kalturaServer.getAdminSecret() : kalturaServer
-			.getUserSecret();
+    if (!Check.isEmpty(keywords) && keywords != null) {
+      joined = Joiner.on(',').join(keywords).trim();
+      joined = joined.replaceAll("[\\*\\?\\~]", "");
+      if (!Objects.equals(joined, "")) {
+        ef.setTagsNameMultiLikeOr(joined.toLowerCase());
+        ef.setMediaTypeIn(
+            Joiner.on(",").join(MediaType.VIDEO.getValue(), MediaType.AUDIO.getValue()));
+        ef.setOrderBy("+name");
+        FilterPager pager = new FilterPager();
+        pager.setPageSize(limit);
+        pager.setPageIndex(page);
 
-		KalturaConfiguration kConfig = new KalturaConfiguration();
-		kConfig.setEndpoint(kalturaServer.getEndPoint());
+        try {
+          return execute(MediaService.list(ef, pager).build(client));
+        } catch (APIException e) {
+          throw new RuntimeException(e);
+        }
+      }
+    }
 
-		KalturaClient kClient = new KalturaClient(kConfig);
+    // No results (or blank search)
+    return null;
+  }
 
-		try
-		{
-			String ks = kClient.getSessionService().start(secret, "", type, pid);
-			kClient.setSessionId(ks);
+  @Override
+  public Client getKalturaClient(KalturaServer kalturaServer, SessionType type)
+      throws APIException {
+    int pid = kalturaServer.getPartnerId();
+    String secret =
+        type.equals(SessionType.ADMIN)
+            ? kalturaServer.getAdminSecret()
+            : kalturaServer.getUserSecret();
 
-			return kClient;
-		}
-		catch( Exception ex )
-		{
-			throw new KalturaApiException();
-		}
-	}
+    Configuration kConfig = new Configuration();
+    kConfig.setEndpoint(kalturaServer.getEndPoint());
 
-	@Override
-	public boolean isUp(KalturaServer ks)
-	{
-		if( ks == null )
-		{
-			return false;
-		}
+    Client kClient = new Client(kConfig);
 
-		KalturaConfiguration kConfig = new KalturaConfiguration();
-		kConfig.setEndpoint(ks.getEndPoint());
+    try {
+      String ks = execute(SessionService.start(secret, "", type, pid).build(kClient));
 
-		try
-		{
-			new KalturaClient(kConfig).getSystemService().ping();
-		}
-		catch( KalturaApiException e )
-		{
-			return false;
-		}
-		return true;
-	}
+      kClient.setSessionId(ks);
 
-	@Override
-	public KalturaMediaEntry getMediaEntry(KalturaClient client, String entryId)
-	{
-		try
-		{
-			return client.getMediaService().get(entryId);
-		}
-		catch( KalturaApiException e )
-		{
-			throw Throwables.propagate(e);
-		}
-	}
+      return kClient;
+    } catch (Exception ex) {
+      throw new APIException();
+    }
+  }
 
-	private KalturaUiConf fetchCachedUiConf(KalturaServer ks)
-	{
-		return Optional.ofNullable(ks.getUuid())
-				.map(defaultUiConfCache::getIfPresent)
-				.orElse(null);
-	}
+  @Override
+  public boolean isUp(KalturaServer ks) {
+    if (ks == null) {
+      return false;
+    }
 
-	private KalturaUiConf putCachedUiConf(KalturaServer ks, KalturaUiConf conf)
-	{
-		Optional.ofNullable(ks.getUuid())
-				.ifPresent(uuid -> defaultUiConfCache.put(uuid, conf));
+    Configuration config = new Configuration();
+    config.setEndpoint(ks.getEndPoint());
 
-		return conf;
-	}
+    try {
+      execute(SystemService.ping().build(new Client(config)));
+    } catch (APIException e) {
+      return false;
+    }
+    return true;
+  }
 
-	@Override
-	public KalturaUiConf getDefaultKdpUiConf(KalturaServer ks)
-	{
-		KalturaUiConf conf = fetchCachedUiConf(ks);
-		if (conf != null)
-		{
-			return conf;
-		}
+  @Override
+  public MediaEntry getMediaEntry(Client client, String entryId) {
+    try {
+      return execute(MediaService.get(entryId).build(client));
+    } catch (APIException e) {
+      throw new RuntimeException(e);
+    }
+  }
 
-		try
-		{
-			KalturaClient kc = getKalturaClient(ks, KalturaSessionType.ADMIN);
+  private UiConf fetchCachedUiConf(KalturaServer ks) {
+    return Optional.ofNullable(ks.getUuid()).map(defaultUiConfCache::getIfPresent).orElse(null);
+  }
 
-			KalturaUiConfFilter kcf = new KalturaUiConfFilter();
-			kcf.nameLike = "EQUELLA-KDP-UICONF_5.2";
-			kcf.objTypeEqual = KalturaUiConfObjType.PLAYER_V3;
-			KalturaUiConfService uiConfService = kc.getUiConfService();
-			KalturaUiConfListResponse uiList = uiConfService.list(kcf);
+  private UiConf putCachedUiConf(KalturaServer ks, UiConf conf) {
+    Optional.ofNullable(ks.getUuid()).ifPresent(uuid -> defaultUiConfCache.put(uuid, conf));
 
-			if( uiList.totalCount == 0 )
-			{
-				// No Configs add default
-				conf = createDefaultKDPUiConf(uiConfService);
-			}
-			else if( uiList.totalCount > 1 )
-			{
-				// More than 1 delete all and add default
-				for( KalturaUiConf uiConf : uiList.objects )
-				{
-					uiConfService.delete(uiConf.id);
-				}
+    return conf;
+  }
 
-				conf = createDefaultKDPUiConf(uiConfService);
-			}
-			else
-			{
-				// If there is one is it the latest
-				conf = uiList.objects.get(0);
-				if( !conf.name.equals(EQUELLA_KDP_UICONF) )
-				{
-					uiConfService.delete(conf.id);
-					conf = createDefaultKDPUiConf(uiConfService);
-				}
-			}
+  @Override
+  public UiConf getDefaultKdpUiConf(KalturaServer ks) {
+    UiConf conf = fetchCachedUiConf(ks);
+    if (conf != null) {
+      return conf;
+    }
 
-			return putCachedUiConf(ks, conf);
-		}
-		catch( Exception e )
-		{
-			Throwables.propagate(e);
-		}
+    try {
+      Client kc = getKalturaClient(ks, SessionType.ADMIN);
 
-		return null;
-	}
+      UiConfFilter kcf = new UiConfFilter();
+      kcf.setNameLike("EQUELLA-KDP-UICONF_5.2");
+      kcf.setObjTypeEqual(UiConfObjType.PLAYER_V3);
 
-	private KalturaUiConf createDefaultKDPUiConf(KalturaUiConfService uiConfService) throws IOException,
-		KalturaApiException
-	{
-		KalturaUiConf equellaKdpUiConf = new KalturaUiConf();
-		equellaKdpUiConf.objType = KalturaUiConfObjType.PLAYER_V3;
-		equellaKdpUiConf.creationMode = KalturaUiConfCreationMode.ADVANCED;
-		equellaKdpUiConf.swfUrl = "/flash/kdp3/v3.5.35/kdp3.swf";
-		equellaKdpUiConf.confFile = readUiConfXml("default_kdp_ui_conf.xml");
-		equellaKdpUiConf.name = EQUELLA_KDP_UICONF;
-		equellaKdpUiConf.tags = "kdp3,player";
-		equellaKdpUiConf.useCdn = true;
+      ListResponse<UiConf> uiList = execute(UiConfService.list(kcf).build(kc));
 
-		return uiConfService.add(equellaKdpUiConf);
-	}
+      if (uiList.getTotalCount() == 0) {
+        // No Configs add default
+        conf = createDefaultKDPUiConf(kc);
+      } else if (uiList.getTotalCount() > 1) {
+        // More than 1 delete all and add default
+        for (UiConf uiConf : uiList.getObjects()) {
+          execute(UiConfService.delete(uiConf.getId()).build(kc));
+        }
 
-	private String readUiConfXml(String filename) throws IOException
-	{
-		return Resources.toString(KalturaServiceImpl.class.getResource(filename), Charsets.UTF_8);
-	}
+        conf = createDefaultKDPUiConf(kc);
+      } else {
+        // If there is one is it the latest
+        conf = uiList.getObjects().get(0);
+        if (!conf.getName().equals(EQUELLA_KDP_UICONF)) {
+          execute(UiConfService.delete(conf.getId()).build(kc));
+          conf = createDefaultKDPUiConf(kc);
+        }
+      }
 
-	@Override
-	public boolean testKalturaSetup(KalturaServer kalturaServer, KalturaSessionType type) throws KalturaApiException
-	{
-		KalturaClient kclient = null;
-		try
-		{
-			kclient = getKalturaClient(kalturaServer, type);
-			return !Check.isEmpty(kclient.getSessionId());
-		}
-		finally
-		{
-			if( kclient != null )
-			{
-				KalturaSessionService ss = kclient.getSessionService();
-				ss.end();
-			}
-		}
-	}
+      return putCachedUiConf(ks, conf);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
 
-	@Override
-	public KalturaMediaListResponse getMediaEntries(KalturaClient client, List<String> entryIds)
-	{
-		try
-		{
-			KalturaMediaEntryFilter filter = new KalturaMediaEntryFilter();
-			filter.idIn = Joiner.on(',').join(entryIds);
-			filter.statusIn = Joiner.on(',').join(KalturaEntryStatus.READY.hashCode,
-				KalturaEntryStatus.PENDING.hashCode, KalturaEntryStatus.PRECONVERT.hashCode);
+  private UiConf createDefaultKDPUiConf(Client client) throws IOException, APIException {
+    UiConf equellaKdpUiConf = new UiConf();
+    equellaKdpUiConf.setObjType(UiConfObjType.PLAYER_V3);
+    equellaKdpUiConf.setCreationMode(UiConfCreationMode.ADVANCED);
+    equellaKdpUiConf.setSwfUrl("/flash/kdp3/v3.5.35/kdp3.swf");
+    equellaKdpUiConf.setConfFile(readUiConfXml("default_kdp_ui_conf.xml"));
+    equellaKdpUiConf.setName(EQUELLA_KDP_UICONF);
+    equellaKdpUiConf.setTags("kdp3,player");
+    equellaKdpUiConf.setUseCdn(true);
 
-			KalturaMediaListResponse list = client.getMediaService().list(filter);
+    return execute(UiConfService.add(equellaKdpUiConf).build(client));
+  }
 
-			if( list == null || list.totalCount != entryIds.size() )
-			{
-				// Get each individually
-				list = new KalturaMediaListResponse();
-				for( String id : entryIds )
-				{
-					list.objects.add(client.getMediaService().get(id));
-				}
-			}
+  private String readUiConfXml(String filename) throws IOException {
+    return Resources.toString(KalturaServiceImpl.class.getResource(filename), Charsets.UTF_8);
+  }
 
-			return list;
-		}
-		catch( KalturaApiException e )
-		{
-			throw Throwables.propagate(e);
-		}
-	}
+  @Override
+  public boolean testKalturaSetup(KalturaServer kalturaServer, SessionType type)
+      throws APIException {
+    Client kclient = null;
+    try {
+      kclient = getKalturaClient(kalturaServer, type);
+      return !Check.isEmpty(kclient.getSessionId());
+    } finally {
+      if (kclient != null) {
+        execute(SessionService.end().build(kclient));
+      }
+    }
+  }
 
-	@Override
-	protected void doValidation(EntityEditingSession<EntityEditingBean, KalturaServer> session, KalturaServer ks,
-		List<ValidationError> errors)
-	{
-		addIfEmpty(errors, LangUtils.isEmpty(ks.getName()), "name");
-		addIfEmpty(errors, Check.isEmpty(ks.getEndPoint()), "endpoint");
-		addIfEmpty(errors, ks.getPartnerId() == 0, "partnerid");
-		addIfInvalid(errors, ks.getPartnerId() == -1, "partnerid");
-		addIfInvalid(errors, ks.getSubPartnerId() == -1, "subpartnerid");
-		addIfEmpty(errors, Check.isEmpty(ks.getAdminSecret()), "adminsecret");
-		addIfEmpty(errors, Check.isEmpty(ks.getUserSecret()), "usersecret");
-	}
+  @Override
+  public ListResponse<MediaEntry> getMediaEntries(Client client, List<String> entryIds) {
+    try {
+      MediaEntryFilter filter = new MediaEntryFilter();
+      filter.setIdIn(Joiner.on(',').join(entryIds));
+      filter.setStatusIn(
+          Joiner.on(',')
+              .join(
+                  EntryStatus.READY.getValue(),
+                  EntryStatus.PENDING.getValue(),
+                  EntryStatus.PRECONVERT.getValue()));
 
-	private void addIfEmpty(List<ValidationError> errors, boolean empty, String field)
-	{
-		if( empty )
-		{
-			errors.add(new ValidationError(field, "mandatory"));
-		}
-	}
+      ListResponse<MediaEntry> list = execute(MediaService.list(filter).build(client));
 
-	private void addIfInvalid(List<ValidationError> errors, boolean invalid, String field)
-	{
-		if( invalid )
-		{
-			errors.add(new ValidationError(field, "invalid"));
-		}
-	}
+      if (list == null || list.getTotalCount() != entryIds.size()) {
+        // Get each individually
+        list = new ListResponse<>();
+        for (String id : entryIds) {
+          list.getObjects().add(execute(MediaService.get(id).build(client)));
+        }
+      }
 
-	@Override
-	public boolean canDelete(BaseEntityLabel kalturaServer)
-	{
-		return canDelete((Object) kalturaServer);
-	}
+      return list;
+    } catch (APIException e) {
+      throw new RuntimeException(e);
+    }
+  }
 
-	private boolean canDelete(Object server)
-	{
-		Set<String> privs = new HashSet<String>();
-		privs.add(KalturaConstants.PRIV_DELETE_KALTURA);
-		return !aclManager.filterNonGrantedPrivileges(server, privs).isEmpty();
-	}
+  @Override
+  protected void doValidation(
+      EntityEditingSession<EntityEditingBean, KalturaServer> session,
+      KalturaServer ks,
+      List<ValidationError> errors) {
+    addIfEmpty(errors, LangUtils.isEmpty(ks.getName()), "name");
+    addIfEmpty(errors, Check.isEmpty(ks.getEndPoint()), "endpoint");
+    addIfEmpty(errors, ks.getPartnerId() == 0, "partnerid");
+    addIfInvalid(errors, ks.getPartnerId() == -1, "partnerid");
+    addIfInvalid(errors, ks.getSubPartnerId() == -1, "subpartnerid");
+    addIfEmpty(errors, Check.isEmpty(ks.getAdminSecret()), "adminsecret");
+    addIfEmpty(errors, Check.isEmpty(ks.getUserSecret()), "usersecret");
+  }
 
-	@Override
-	public boolean canEdit(BaseEntityLabel kalturaServer)
-	{
-		return canEdit((Object) kalturaServer);
-	}
+  private void addIfEmpty(List<ValidationError> errors, boolean empty, String field) {
+    if (empty) {
+      errors.add(new ValidationError(field, "mandatory"));
+    }
+  }
 
-	@Override
-	public boolean canEdit(KalturaServer kalturaServer)
-	{
-		return canEdit((Object) kalturaServer);
-	}
+  private void addIfInvalid(List<ValidationError> errors, boolean invalid, String field) {
+    if (invalid) {
+      errors.add(new ValidationError(field, "invalid"));
+    }
+  }
 
-	private boolean canEdit(Object kalturaServer)
-	{
-		Set<String> privs = new HashSet<String>();
-		privs.add(KalturaConstants.PRIV_EDIT_KALTURA);
-		return !aclManager.filterNonGrantedPrivileges(kalturaServer, privs).isEmpty();
-	}
+  @Override
+  public boolean canDelete(BaseEntityLabel kalturaServer) {
+    return canDelete((Object) kalturaServer);
+  }
 
-	@Override
-	@SecureOnReturn(priv = KalturaConstants.PRIV_EDIT_KALTURA)
-	public KalturaServer getForEdit(String kalturaServerUuid)
-	{
-		return getByUuid(kalturaServerUuid);
-	}
+  private boolean canDelete(Object server) {
+    Set<String> privs = new HashSet<String>();
+    privs.add(KalturaConstants.PRIV_DELETE_KALTURA);
+    return !aclManager.filterNonGrantedPrivileges(server, privs).isEmpty();
+  }
 
-	@Override
-	public EntityPack<KalturaServer> startEdit(KalturaServer entity)
-	{
-		throw new UnsupportedOperationException();
-	}
+  @Override
+  public boolean canEdit(BaseEntityLabel kalturaServer) {
+    return canEdit((Object) kalturaServer);
+  }
 
-	@Override
-	public KalturaServer stopEdit(EntityPack<KalturaServer> pack, boolean unlock)
-	{
-		throw new UnsupportedOperationException();
-	}
+  @Override
+  public boolean canEdit(KalturaServer kalturaServer) {
+    return canEdit((Object) kalturaServer);
+  }
 
-	@Override
-	public String addKalturaServer(KalturaServer kalturaServer)
-	{
-		EntityPack<KalturaServer> pack = new EntityPack<KalturaServer>();
-		pack.setEntity(kalturaServer);
-		return add(pack, false).getUuid();
-	}
+  private boolean canEdit(Object kalturaServer) {
+    Set<String> privs = new HashSet<String>();
+    privs.add(KalturaConstants.PRIV_EDIT_KALTURA);
+    return !aclManager.filterNonGrantedPrivileges(kalturaServer, privs).isEmpty();
+  }
 
-	@Override
-	@Transactional
-	public void editKalturaServer(String uuid, KalturaServer newServer) throws InvalidDataException
-	{
-		KalturaServer oldServer = getForEdit(uuid);
+  @Override
+  @SecureOnReturn(priv = KalturaConstants.PRIV_EDIT_KALTURA)
+  public KalturaServer getForEdit(String kalturaServerUuid) {
+    return getByUuid(kalturaServerUuid);
+  }
 
-		// Common details
-		editCommonFields(oldServer, newServer);
+  @Override
+  public EntityPack<KalturaServer> startEdit(KalturaServer entity) {
+    throw new UnsupportedOperationException();
+  }
 
-		// Other details
-		oldServer.setEndPoint(newServer.getEndPoint());
-		oldServer.setPartnerId(newServer.getPartnerId());
-		oldServer.setSubPartnerId(newServer.getSubPartnerId());
-		oldServer.setAdminSecret(newServer.getAdminSecret());
-		oldServer.setUserSecret(newServer.getUserSecret());
-		oldServer.setKdpUiConfId(newServer.getKdpUiConfId());
+  @Override
+  public KalturaServer stopEdit(EntityPack<KalturaServer> pack, boolean unlock) {
+    throw new UnsupportedOperationException();
+  }
 
-		// Validate
-		validate(null, oldServer);
+  @Override
+  public String addKalturaServer(KalturaServer kalturaServer) {
+    EntityPack<KalturaServer> pack = new EntityPack<KalturaServer>();
+    pack.setEntity(kalturaServer);
+    return add(pack, false).getUuid();
+  }
 
-		kalturaDao.update(oldServer);
-	}
+  @Override
+  @Transactional
+  public void editKalturaServer(String uuid, KalturaServer newServer) throws InvalidDataException {
+    KalturaServer oldServer = getForEdit(uuid);
 
-	// The method 'throws RuntimeException', but seeing as that throws
-	// declaration is technically superfluous, we can omit it to keep Sonar
-	// happy
-	@Override
-	public List<KalturaUiConf> getPlayers(KalturaServer ks)
-	{
-		KalturaClient kc;
-		try
-		{
-			kc = getKalturaClient(ks, KalturaSessionType.ADMIN);
-			KalturaUiConfFilter uiConfFilter = new KalturaUiConfFilter();
-			uiConfFilter.objTypeEqual = KalturaUiConfObjType.PLAYER;
-			return kc.getUiConfService().list(uiConfFilter).objects;
-		}
-		catch( KalturaApiException e )
-		{
-			Throwables.propagate(e);
-		}
-		return null;
-	}
+    // Common details
+    editCommonFields(oldServer, newServer);
 
-	@Override
-	@Transactional
-	public void enable(KalturaServer ks, boolean enable)
-	{
-		ks.setEnabled(enable);
-		kalturaDao.update(ks);
-	}
+    // Other details
+    oldServer.setEndPoint(newServer.getEndPoint());
+    oldServer.setPartnerId(newServer.getPartnerId());
+    oldServer.setSubPartnerId(newServer.getSubPartnerId());
+    oldServer.setAdminSecret(newServer.getAdminSecret());
+    oldServer.setUserSecret(newServer.getUserSecret());
+    oldServer.setKdpUiConfId(newServer.getKdpUiConfId());
 
-	@Override
-	public boolean hasConf(KalturaServer ks, String confId)
-	{
-		KalturaClient client = null;
+    // Validate
+    validate(null, oldServer);
 
-		try
-		{
-			client = getKalturaClient(ks, KalturaSessionType.ADMIN);
-			KalturaUiConf conf = client.getUiConfService().get(Integer.parseInt(confId));
-			return conf != null;
-		}
-		catch( KalturaApiException e )
-		{
-			return false;
-		}
-	}
+    kalturaDao.update(oldServer);
+  }
+
+  // The method 'throws RuntimeException', but seeing as that throws
+  // declaration is technically superfluous, we can omit it to keep Sonar
+  // happy
+  @Override
+  public List<UiConf> getPlayers(KalturaServer ks) {
+    Client kc;
+    try {
+      kc = getKalturaClient(ks, SessionType.ADMIN);
+      UiConfFilter uiConfFilter = new UiConfFilter();
+      uiConfFilter.setObjTypeEqual(UiConfObjType.PLAYER);
+      return execute(UiConfService.list(uiConfFilter).build(kc)).getObjects();
+    } catch (APIException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  @Transactional
+  public void enable(KalturaServer ks, boolean enable) {
+    ks.setEnabled(enable);
+    kalturaDao.update(ks);
+  }
+
+  @Override
+  public boolean hasConf(KalturaServer ks, String confId) {
+    Client client = null;
+
+    try {
+      client = getKalturaClient(ks, SessionType.ADMIN);
+      UiConf conf = execute(UiConfService.get(Integer.parseInt(confId)).build(client));
+      return conf != null;
+    } catch (APIException e) {
+      return false;
+    }
+  }
 }

--- a/Kaltura/com.tle.web.kaltura/src/com/tle/web/kaltura/section/KalturaServerEditorSection.java
+++ b/Kaltura/com.tle.web.kaltura/src/com/tle/web/kaltura/section/KalturaServerEditorSection.java
@@ -16,30 +16,21 @@
 
 package com.tle.web.kaltura.section;
 
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-
-import javax.inject.Inject;
-
-import com.tle.common.beans.exception.ValidationError;
-import com.tle.common.beans.exception.InvalidDataException;
 import com.google.common.collect.Lists;
-import com.kaltura.client.enums.KalturaSessionType;
-import com.kaltura.client.types.KalturaUiConf;
+import com.kaltura.client.enums.SessionType;
+import com.kaltura.client.types.UiConf;
 import com.tle.beans.entity.LanguageBundle;
 import com.tle.common.Check;
 import com.tle.common.NameValue;
+import com.tle.common.beans.exception.InvalidDataException;
+import com.tle.common.beans.exception.ValidationError;
 import com.tle.common.i18n.LangUtils;
 import com.tle.common.kaltura.entity.KalturaServer;
 import com.tle.core.guice.Bind;
+import com.tle.core.i18n.BundleNameValue;
 import com.tle.core.kaltura.service.KalturaService;
 import com.tle.web.freemarker.FreemarkerFactory;
 import com.tle.web.freemarker.annotations.ViewFactory;
-import com.tle.core.i18n.BundleNameValue;
 import com.tle.web.resources.ResourcesService;
 import com.tle.web.sections.SectionInfo;
 import com.tle.web.sections.SectionResult;
@@ -78,6 +69,13 @@ import com.tle.web.sections.standard.annotations.Component;
 import com.tle.web.sections.standard.model.DynamicHtmlListModel;
 import com.tle.web.template.Breadcrumbs;
 import com.tle.web.template.Decorations;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import javax.inject.Inject;
 
 @SuppressWarnings("nls")
 @Bind
@@ -203,10 +201,10 @@ public class KalturaServerEditorSection
 				if( getModel(info).isSuccessful() )
 				{
 					KalturaServer ks = getDetailsFromForm(info);
-					List<KalturaUiConf> players = kalturaService.getPlayers(ks);
-					for( KalturaUiConf uiConf : players )
+					List<UiConf> players = kalturaService.getPlayers(ks);
+					for( UiConf uiConf : players )
 					{
-						opts.add(new NameValue(uiConf.name, Integer.toString(uiConf.id)));
+						opts.add(new NameValue(uiConf.getName(), Integer.toString(uiConf.getId())));
 					}
 
 					Collections.sort(opts, new Comparator<NameValue>()
@@ -221,7 +219,7 @@ public class KalturaServerEditorSection
 					opts.add(
 						0,
 						new BundleNameValue(EQUELLA_DEFAULT,
-							Integer.toString(kalturaService.getDefaultKdpUiConf(ks).id)));
+							Integer.toString(kalturaService.getDefaultKdpUiConf(ks).getId())));
 				}
 				return opts;
 			}
@@ -433,9 +431,8 @@ public class KalturaServerEditorSection
 		boolean success = false;
 		try
 		{
-			success = kalturaService.testKalturaSetup(ks, KalturaSessionType.ADMIN)
-				&& kalturaService.testKalturaSetup(ks, KalturaSessionType.USER);
-
+			success = kalturaService.testKalturaSetup(ks, SessionType.ADMIN)
+				&& kalturaService.testKalturaSetup(ks, SessionType.USER);
 		}
 		catch( Exception e )
 		{

--- a/Kaltura/com.tle.web.kaltura/src/com/tle/web/kaltura/viewer/KalturaPreviewRenderer.java
+++ b/Kaltura/com.tle.web.kaltura/src/com/tle/web/kaltura/viewer/KalturaPreviewRenderer.java
@@ -128,7 +128,7 @@ public class KalturaPreviewRenderer implements VideoPreviewRenderer
 		}
 
 		// EQUELLA default
-		uiConfId = Integer.toString(kalturaService.getDefaultKdpUiConf(ks).id);
+		uiConfId = Integer.toString(kalturaService.getDefaultKdpUiConf(ks).getId());
 		return uiConfId;
 	}
 

--- a/Kaltura/com.tle.web.kaltura/src/com/tle/web/kaltura/viewer/KalturaViewerSection.java
+++ b/Kaltura/com.tle.web.kaltura/src/com/tle/web/kaltura/viewer/KalturaViewerSection.java
@@ -130,7 +130,7 @@ public class KalturaViewerSection extends AbstractViewerSection<Object>
 		}
 
 		// EQUELLA default
-		uiConfId = Integer.toString(kalturaService.getDefaultKdpUiConf(ks).id);
+		uiConfId = Integer.toString(kalturaService.getDefaultKdpUiConf(ks).getId());
 		return uiConfId;
 	}
 

--- a/Kaltura/com.tle.web.wizard.controls.kaltura/src/com/tle/web/controls/kaltura/KalturaAttachmentSerializer.java
+++ b/Kaltura/com.tle.web.wizard.controls.kaltura/src/com/tle/web/controls/kaltura/KalturaAttachmentSerializer.java
@@ -72,7 +72,7 @@ public class KalturaAttachmentSerializer extends AbstractAttachmentSerializer
 		}
 
 		KalturaServer ks = kalturaService.getByUuid(kbean.getKalturaServer());
-		kbean.setExternalId(ks.getPartnerId(), kalturaService.getDefaultKdpUiConf(ks).id);
+		kbean.setExternalId(ks.getPartnerId(), kalturaService.getDefaultKdpUiConf(ks).getId());
 
 		return kbean;
 	}


### PR DESCRIPTION
Due to the Log4J update, KalturaClient v3.2.1 no longer works. And this version is really too old.

This means it's time to updates KalturaClient to the latest version v17.18.1. 

However,  there are plenty of breaking changes.  So I also updated code where KalturaClient is used.

Most significant changes were made in `KalturaServiceImpl` around how to send a request to manage Kaltura resources.

I have tested:
1. Adding a new Kaltura server in the setting page. Clicking the test connection button showed me a successful connection.
2. Uploading a video in Wizard.
3. Searching for the video in Wizard.
4. Viewing the video in new search UI.