### PR TITLE
chore: update KalturaApiClient to v21.12.0

### DIFF
--- a/Kaltura/com.tle.core.kaltura/build.sbt
+++ b/Kaltura/com.tle.core.kaltura/build.sbt
@@ -1,7 +1,7 @@
 lazy val Kaltura = config("kaltura") describedAs("kaltura jars")
 lazy val CustomCompile = config("compile") extend Kaltura
 
-libraryDependencies += "com.kaltura" % "kalturaApiClient" % "17.18.1" % Kaltura
+libraryDependencies += "com.kaltura" % "KalturaApiClient" % "21.12.0" % Kaltura
 
 excludeDependencies := Seq(
   "commons-logging" % "commons-logging",


### PR DESCRIPTION
This PR upgrades the Kaltura API Client from v17 to v21. This big upgrade surprisingly does not require any code changes, which sounds too good to be true. But I tested the whole integration, including:
* Searching videos
* Adding a new video
* Watching a video in the new Search page and the Legacy Item summary page
* Connection testing in the Kaltura setting page

And all of above features work normally.