### PR TITLE
OEQ-2823 - feat(KalturaService): add caching getPlayerConfig

### DIFF
--- a/Kaltura/com.tle.core.kaltura/src/com/tle/core/kaltura/service/KalturaServiceImpl.java
+++ b/Kaltura/com.tle.core.kaltura/src/com/tle/core/kaltura/service/KalturaServiceImpl.java
@@ -92,7 +92,8 @@ public class KalturaServiceImpl
 
   private static final String DEFAULT_KALTURA_PLAYER_PREFIX = "OEQ_DEFAULT_KALTURA_PLAYER";
 
-  private static final String DEFAULT_KALTURA_PLAYER_NAME = DEFAULT_KALTURA_PLAYER_PREFIX + "_V7_LATEST";
+  private static final String DEFAULT_KALTURA_PLAYER_NAME =
+      DEFAULT_KALTURA_PLAYER_PREFIX + "_V7_LATEST";
 
   private static final String KALTURA_CDN = "https://cdnapisec.kaltura.com";
 
@@ -203,8 +204,7 @@ public class KalturaServiceImpl
   }
 
   private Optional<UiConf> fetchCachedUiConf(KalturaServer ks) {
-    return Optional.ofNullable(ks.getUuid())
-      .map(defaultUiConfCache::getIfPresent);
+    return Optional.ofNullable(ks.getUuid()).map(defaultUiConfCache::getIfPresent);
   }
 
   private UiConf putCachedUiConf(KalturaServer ks, UiConf conf) {
@@ -215,8 +215,8 @@ public class KalturaServiceImpl
 
   private Optional<UiConf> fetchCachedPlayerConfig(KalturaServer ks, int confId) {
     return Optional.ofNullable(ks.getUuid())
-      .map(uuid -> uuid + ":" + confId)
-      .map(playerConfigCache::getIfPresent);
+        .map(uuid -> uuid + ":" + confId)
+        .map(playerConfigCache::getIfPresent);
   }
 
   private UiConf putCachedPlayerConfig(KalturaServer ks, int confId, UiConf conf) {
@@ -276,9 +276,7 @@ public class KalturaServiceImpl
 
   private String defaultV7PlayerConf() throws IOException {
     return Resources.toString(
-        getClass().getResource("default_v7_player_conf.json"),
-        Charsets.UTF_8
-    );
+        getClass().getResource("default_v7_player_conf.json"), Charsets.UTF_8);
   }
 
   private UiConf createDefaultKDPUiConf(Client client) throws IOException, APIException {
@@ -464,13 +462,16 @@ public class KalturaServiceImpl
   @Override
   public UiConf getPlayerConfig(KalturaServer ks, String confId) {
     try {
-      int playerId = Optional.ofNullable(confId)
-          .filter(StringUtils::isNotEmpty)
-          .map(Integer::parseInt)
-          .orElseGet( () -> {
-            LOGGER.debug("No conf ID provided, use the ID configured in Kaltura setting instead.");
-            return ks.getKdpUiConfId();
-          });
+      int playerId =
+          Optional.ofNullable(confId)
+              .filter(StringUtils::isNotEmpty)
+              .map(Integer::parseInt)
+              .orElseGet(
+                  () -> {
+                    LOGGER.debug(
+                        "No conf ID provided, use the ID configured in Kaltura setting instead.");
+                    return ks.getKdpUiConfId();
+                  });
 
       Optional<UiConf> cachedConf = fetchCachedPlayerConfig(ks, playerId);
       if (cachedConf.isPresent()) {
@@ -482,10 +483,11 @@ public class KalturaServiceImpl
       return putCachedPlayerConfig(ks, playerId, conf);
     } catch (APIException | NumberFormatException e) {
       LOGGER.warn(
-        "Failed to get Kaltura player details for {}, using the OEQ default player instead.",
-        confId, e);
+          "Failed to get Kaltura player details for {}, using the OEQ default player instead.",
+          confId,
+          e);
       // Intentionally not caching the fallback result to encourage fixing configuration issues
-      return  getDefaultKdpUiConf(ks);
+      return getDefaultKdpUiConf(ks);
     }
   }
 
@@ -495,8 +497,8 @@ public class KalturaServiceImpl
   }
 
   @Override
-  public String createPlayerEmbedUrl(IAttachment attachment, String playerId, boolean autoEmbed,
-      String uiConfId) {
+  public String createPlayerEmbedUrl(
+      IAttachment attachment, String playerId, boolean autoEmbed, String uiConfId) {
     String entryId = (String) attachment.getData(KalturaUtils.PROPERTY_ENTRY_ID);
 
     String ksUuid = (String) attachment.getData(KalturaUtils.PROPERTY_KALTURA_SERVER);
@@ -505,20 +507,22 @@ public class KalturaServiceImpl
     UiConf playerConfig = getPlayerConfig(ks, uiConfId);
     String embedType = autoEmbed ? "autoembed" : "iframeembed";
 
-    // The Kaltura support team has confirmed that using `playerConfig.getHtml5Url() == null`  is a valid approach
+    // The Kaltura support team has confirmed that using `playerConfig.getHtml5Url() == null`  is a
+    // valid approach
     // to determine whether a player is v2 or v7.
-    String embedUrlPattern = playerConfig.getHtml5Url() == null ?
-        "{0}/p/{1}/embedPlaykitJs/uiconf_id/{3}/?{4}=true&targetId={5}&entry_id={6}":
-        "{0}/p/{1}/sp/{2}/embedIframeJs/uiconf_id/{3}/partner_id/{1}?{4}=true&playerId={5}&entry_id={6}";
+    String embedUrlPattern =
+        playerConfig.getHtml5Url() == null
+            ? "{0}/p/{1}/embedPlaykitJs/uiconf_id/{3}/?{4}=true&targetId={5}&entry_id={6}"
+            : "{0}/p/{1}/sp/{2}/embedIframeJs/uiconf_id/{3}/partner_id/{1}?{4}=true&playerId={5}&entry_id={6}";
 
-    return MessageFormat.format(embedUrlPattern,
+    return MessageFormat.format(
+        embedUrlPattern,
         KALTURA_CDN,
         Integer.toString(ks.getPartnerId()),
         Integer.toString(ks.getSubPartnerId()),
         Integer.toString(playerConfig.getId()),
         embedType,
         playerId,
-        entryId
-    );
+        entryId);
   }
 }

--- a/Kaltura/com.tle.core.kaltura/src/com/tle/core/kaltura/service/KalturaServiceImpl.java
+++ b/Kaltura/com.tle.core.kaltura/src/com/tle/core/kaltura/service/KalturaServiceImpl.java
@@ -213,15 +213,19 @@ public class KalturaServiceImpl
     return conf;
   }
 
+  private String playerConfigCacheKey(String uuid, int confId) {
+    return uuid + ":" + confId;
+  }
+
   private Optional<UiConf> fetchCachedPlayerConfig(KalturaServer ks, int confId) {
     return Optional.ofNullable(ks.getUuid())
-        .map(uuid -> uuid + ":" + confId)
+        .map(uuid -> playerConfigCacheKey(uuid, confId))
         .map(playerConfigCache::getIfPresent);
   }
 
   private UiConf putCachedPlayerConfig(KalturaServer ks, int confId, UiConf conf) {
     Optional.ofNullable(ks.getUuid())
-        .ifPresent(uuid -> playerConfigCache.put(uuid + ":" + confId, conf));
+        .ifPresent(uuid -> playerConfigCache.put(playerConfigCacheKey(uuid, confId), conf));
 
     return conf;
   }

--- a/Kaltura/com.tle.core.kaltura/src/com/tle/core/kaltura/service/KalturaServiceImpl.java
+++ b/Kaltura/com.tle.core.kaltura/src/com/tle/core/kaltura/service/KalturaServiceImpl.java
@@ -88,7 +88,7 @@ public class KalturaServiceImpl
 
   protected final KalturaDao kalturaDao;
 
-  private APIOkRequestsExecutor executor = new APIOkRequestsExecutor();
+  private final APIOkRequestsExecutor executor = new APIOkRequestsExecutor();
 
   private static final String DEFAULT_KALTURA_PLAYER_PREFIX = "OEQ_DEFAULT_KALTURA_PLAYER";
 
@@ -105,6 +105,11 @@ public class KalturaServiceImpl
   // A cache to protect against excessive calls to Kaltura. There is a small risk of a period when
   // incorrect results could then be returned - however if needs be a restart can navigate it.
   private final Cache<String, UiConf> defaultUiConfCache =
+      CacheBuilder.newBuilder().expireAfterWrite(1, TimeUnit.HOURS).build();
+
+  // This cache is similar to the above but was introduced due to performance issues in the New UI
+  // search results via search2.
+  private final Cache<String, UiConf> playerConfigCache =
       CacheBuilder.newBuilder().expireAfterWrite(1, TimeUnit.HOURS).build();
 
   private <T> T execute(RequestElement<T> request) throws APIException {
@@ -197,8 +202,9 @@ public class KalturaServiceImpl
     }
   }
 
-  private UiConf fetchCachedUiConf(KalturaServer ks) {
-    return Optional.ofNullable(ks.getUuid()).map(defaultUiConfCache::getIfPresent).orElse(null);
+  private Optional<UiConf> fetchCachedUiConf(KalturaServer ks) {
+    return Optional.ofNullable(ks.getUuid())
+      .map(defaultUiConfCache::getIfPresent);
   }
 
   private UiConf putCachedUiConf(KalturaServer ks, UiConf conf) {
@@ -207,11 +213,30 @@ public class KalturaServiceImpl
     return conf;
   }
 
+  private Optional<UiConf> fetchCachedPlayerConfig(KalturaServer ks, int confId) {
+    return Optional.ofNullable(ks.getUuid())
+      .map(uuid -> uuid + ":" + confId)
+      .map(playerConfigCache::getIfPresent);
+  }
+
+  private UiConf putCachedPlayerConfig(KalturaServer ks, int confId, UiConf conf) {
+    Optional.ofNullable(ks.getUuid())
+        .ifPresent(uuid -> playerConfigCache.put(uuid + ":" + confId, conf));
+
+    return conf;
+  }
+
+  private void invalidateCachesForServer(String uuid) {
+    defaultUiConfCache.invalidate(uuid);
+    // Invalidate all player config cache entries for this server
+    playerConfigCache.asMap().keySet().removeIf(key -> key.startsWith(uuid + ":"));
+  }
+
   @Override
   public UiConf getDefaultKdpUiConf(KalturaServer ks) {
-    UiConf conf = fetchCachedUiConf(ks);
-    if (conf != null) {
-      return conf;
+    Optional<UiConf> cachedConf = fetchCachedUiConf(ks);
+    if (cachedConf.isPresent()) {
+      return cachedConf.get();
     }
 
     try {
@@ -223,6 +248,7 @@ public class KalturaServiceImpl
 
       ListResponse<UiConf> uiList = execute(UiConfService.list(kcf).build(kc));
 
+      UiConf conf;
       if (uiList.getTotalCount() == 0) {
         // No Configs add default
         conf = createDefaultKDPUiConf(kc);
@@ -408,6 +434,8 @@ public class KalturaServiceImpl
     validate(null, oldServer);
 
     kalturaDao.update(oldServer);
+
+    invalidateCachesForServer(uuid);
   }
 
   // The method 'throws RuntimeException', but seeing as that throws
@@ -444,10 +472,19 @@ public class KalturaServiceImpl
             return ks.getKdpUiConfId();
           });
 
+      Optional<UiConf> cachedConf = fetchCachedPlayerConfig(ks, playerId);
+      if (cachedConf.isPresent()) {
+        return cachedConf.get();
+      }
+
       Client client = getKalturaClient(ks, SessionType.ADMIN);
-      return execute(UiConfService.get(playerId).build(client));
+      UiConf conf = execute(UiConfService.get(playerId).build(client));
+      return putCachedPlayerConfig(ks, playerId, conf);
     } catch (APIException | NumberFormatException e) {
-      LOGGER.warn("Failed to get Kaltura player details for " + confId + ", using the OEQ default player instead.", e);
+      LOGGER.warn(
+        "Failed to get Kaltura player details for {}, using the OEQ default player instead.",
+        confId, e);
+      // Intentionally not caching the fallback result to encourage fixing configuration issues
       return  getDefaultKdpUiConf(ks);
     }
   }


### PR DESCRIPTION
## Overview
Successfully implemented caching for `KalturaServiceImpl#getPlayerConfig` following the pattern used by `getDefaultKdpUiConf`, with improvements using `Optional` instead of nullable returns.

## Changes Made

### 1. Added `playerConfigCache` Field

- Separate cache store from `defaultUiConfCache`
- 1-hour expiration matching the existing pattern
- Uses composite keys: `"uuid:confId"`

### 2. Refactored `fetchCachedUiConf` to Return Optional

- Changed return type from `UiConf` to `Optional<UiConf>`
- Eliminates null returns
- Better practice for modern Java

### 3. Updated `getDefaultKdpUiConf` to Use Optional

- Updated to work with Optional-returning `fetchCachedUiConf`

### 4. Added `fetchCachedPlayerConfig` Method

- Returns `Optional<UiConf>` (not nullable)
- Uses composite cache key format: `"uuid:confId"`
- Takes resolved integer `confId` for consistency

### 5. Added `putCachedPlayerConfig` Method

- Stores with composite key
- Returns the `UiConf` for fluent chaining

### 6. Refactored `getPlayerConfig` to Use Caching

- Resolves `confId` to integer early (used for caching)
- Checks cache before making API call
- Caches successful API results
- **Does NOT cache fallback results** - keeps logging warnings to notify of configuration issues

### 7. Added Cache Invalidation in `editKalturaServer`

- Invalidates `defaultUiConfCache` entry for the server
- Removes all `playerConfigCache` entries matching the server UUID
- Ensures cache consistency after server configuration changes

## Key Design Decisions

1. **Optional over null**: Improved code safety and readability
2. **Composite cache key**: `"uuid:confId"` allows caching different player configs per server
3. **Resolved confId**: Cache uses the actual integer ID, not the string parameter
4. **No fallback caching**: Intentionally keeps failures slow to highlight configuration issues
5. **Cache invalidation on edit**: Prevents stale cache data when server settings change
6. **1-hour expiration**: Balances performance with freshness of data

## Benefits

- **Performance**: Reduces API calls to Kaltura for player configuration
- **Consistency**: Same pattern as existing `getDefaultKdpUiConf` caching
- **Better practices**: Uses `Optional` instead of nulls
- **Maintainability**: Clear separation between default UI conf cache and player config cache
- **Debugging**: Fallback failures continue to log warnings for visibility
